### PR TITLE
Build fail fix when SOAP enabled

### DIFF
--- a/include/gsoap/stdsoap2.h
+++ b/include/gsoap/stdsoap2.h
@@ -206,7 +206,7 @@ A commercial use license is available from Genivia, Inc., contact@genivia.com
 #endif
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+# include "../../../src/shared/Config/Config.h"
 # if defined(WITH_OPENSSL)
 #  ifndef HAVE_OPENSSL_SSL_H
 #   undef WITH_OPENSSL


### PR DESCRIPTION
Incorrect path to config file, and file needs stat start with a capital
'C'