### PR TITLE
Make ACE build on other OSes too.

### DIFF
--- a/acelite/ace/config-freebsd.h
+++ b/acelite/ace/config-freebsd.h
@@ -101,6 +101,12 @@
 # define ACE_LACKS_PERFECT_MULTICAST_FILTERING 1
 #endif /* ACE_LACKS_PERFECT_MULTICAST_FILTERING */
 
+#if defined (__ia64) || defined (__x86_64__)
+# define ACE_UINT64_FORMAT_SPECIFIER_ASCII "%lu"
+# define ACE_SSIZE_T_FORMAT_SPECIFIER_ASCII "%ld"
+# define ACE_SIZE_T_FORMAT_SPECIFIER_ASCII "%lu"
+#endif /* __ia64 */
+
 //
 // Version specific settings
 //

--- a/acelite/ace/config-macros.h
+++ b/acelite/ace/config-macros.h
@@ -24,10 +24,33 @@
 #define ACE_HAS_IPV6 1 
 #define ACE_USES_IPV4_IPV6_MIGRATION 1 
 
-#ifdef _WIN32
-#include "ace/config-win32.h"
-#else
-#include "ace/config-linux.h"
+#if defined(_WIN32)
+#  include "ace/config-win32.h"
+#elif defined(__linux) || defined(__linux__)
+#  include "ace/config-linux.h"
+#elif defined(__FreeBSD__)
+#  include "ace/config-freebsd.h"
+#elif defined(__APPLE__)
+#  include <AvailabilityMacros.h>
+#  if defined(MAC_OS_X_VERSION_10_10)
+#    include "ace/config-macosx-yosemite.h"
+#  elif defined(MAC_OS_X_VERSION_10_9)
+#    include "ace/config-macosx-mavericks.h"
+#  elif defined(MAC_OS_X_VERSION_10_8)
+#    include "ace/config-macosx-mountainlion.h"
+#  elif defined(MAC_OS_X_VERSION_10_7)
+#    include "ace/config-macosx-lion.h"
+#  elif defined(MAC_OS_X_VERSION_10_6)
+#    include "ace/config-macosx-snowleopard.h"
+#  elif defined(MAC_OS_X_VERSION_10_5)
+#    include "ace/config-macosx-leopard.h"
+#  elif defined(MAC_OS_X_VERSION_10_4)
+#    include "ace/config-macosx-tiger.h"
+#  elif defined(MAC_OS_X_VERSION_10_3)
+#    include "ace/config-macosx-panther.h"
+#  else
+#    include "ace/config-macosx.h"
+#endif
 #endif
 
 #include "ace/Version.h"

--- a/g3dlite/G3D/platform.h
+++ b/g3dlite/G3D/platform.h
@@ -46,6 +46,9 @@
 
 #ifndef _MSC_VER
 /// Fast call is a register-based optimized calling convention supported only by Visual C++
+#ifdef __FreeBSD__
+#undef __fastcall
+#endif
 #define __fastcall
 #endif
 


### PR DESCRIPTION
Also:
  - Fix 64bit definitions of several ACE_*_FORMAT_SPECIFIER_ASCII on FreeBSD.
  - Fix some warnings during G3D compile on FreeBSD.