### PR TITLE
Correction made to file

### DIFF
--- a/loadlib/adt.h
+++ b/loadlib/adt.h
@@ -478,6 +478,7 @@ class ADT_file : public FileLoader
         void free();
 
         adt_MHDR* a_grid; /**< TODO */
+        adt_MCNK* cells[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
 };
 
 /**

--- a/loadlib/loadlib.cpp
+++ b/loadlib/loadlib.cpp
@@ -153,9 +153,13 @@ bool FileLoader::prepareLoadedData()
     // Check version
     version = (file_MVER*) data;
     if (version->fcc != 'MVER')
-        { return false; }
+    {
+        return false;
+    }
     if (version->ver != FILE_FORMAT_VERSION)
-        { return false; }
+    {
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
Member added to class ADT_file. This was in a subfolder (loadlib) of
map-extractor (Three). That folder was removed in PR:

https://github.com/mangosthree/server/commit/a75579cb4569efef3beaa4ce82eddf41e6192938