### PR TITLE
Corrections made to adt_MHDR class members

### DIFF
--- a/loadlib/adt.cpp
+++ b/loadlib/adt.cpp
@@ -68,7 +68,30 @@ bool ADT_file::prepareLoadedData()
     // Check and prepare MHDR
     a_grid = (adt_MHDR*)(GetData() + 8 + version->size);
     if (!a_grid->prepareLoadedData())
-        { return false; }
+	{
+		return false;
+	}
+
+	// funny offsets calculations because there is no mapping for them and they have variable lengths
+	uint8* ptr = (uint8*)a_grid + a_grid->size + 8;
+	uint32 mcnk_count = 0;
+	memset(cells, 0, ADT_CELLS_PER_GRID * ADT_CELLS_PER_GRID * sizeof(adt_MCNK*));
+	while (ptr < GetData() + GetDataSize())
+	{
+		uint32 header = *(uint32*)ptr;
+		uint32 size = *(uint32*)(ptr + 4);
+		if (header == 'MCNK')
+		{
+			cells[mcnk_count / ADT_CELLS_PER_GRID][mcnk_count % ADT_CELLS_PER_GRID] = (adt_MCNK*)ptr;
+			++mcnk_count;
+		}
+
+		// move to next chunk
+		ptr += size + 8;
+	}
+
+	if (mcnk_count != ADT_CELLS_PER_GRID * ADT_CELLS_PER_GRID)
+		return false;
 
     return true;
 }

--- a/loadlib/adt.h
+++ b/loadlib/adt.h
@@ -408,6 +408,7 @@ class adt_MHDR
             uint32 fcc; /**< TODO */
             char   fcc_txt[4]; /**< TODO */
         };
+    public:
         uint32 size; /**< TODO */
 
         uint32 pad; /**< TODO */
@@ -426,7 +427,6 @@ class adt_MHDR
         uint32 data3; /**< TODO */
         uint32 data4; /**< TODO */
         uint32 data5; /**< TODO */
-    public:
         /**
          * @brief
          *


### PR DESCRIPTION
Corrections made to the class members so that the creation of the .map
files would work for Three (CATA).
Note: this is how it is also done in the extractors for the previous cores.