### PR TITLE
added arm64 compatibility to g3dlite dep

### DIFF
--- a/g3dlite/G3D/AtomicInt32.h
+++ b/g3dlite/G3D/AtomicInt32.h
@@ -73,7 +73,7 @@ public:
 #       if defined(G3D_WIN32)
 
             return InterlockedExchangeAdd(&m_value, x);
-#       elif defined(__arm__)
+#       elif defined(__arm__) || defined(__aarch64__)
 
             return __sync_fetch_and_add(&m_value, 1);
 #       elif defined(G3D_LINUX) || defined(G3D_FREEBSD)
@@ -116,7 +116,7 @@ public:
 #       if defined(G3D_WIN32)
             // Note: returns the newly decremented value
             return InterlockedDecrement(&m_value);
-#       elif defined(__arm__)
+#       elif defined(__arm__) || defined(__aarch64__)
 
             return __sync_sub_and_fetch(&m_value, 1);
 
@@ -148,7 +148,7 @@ public:
     int32 compareAndSet(const int32 comperand, const int32 exchange) {
 #       if defined(G3D_WIN32)
             return InterlockedCompareExchange(&m_value, exchange, comperand);
-#       elif defined(__arm__)
+#       elif defined(__arm__) || defined(__aarch64__)
             return __sync_val_compare_and_swap(&m_value, comperand, exchange);
 #       elif defined(G3D_LINUX) || defined(G3D_FREEBSD) || defined(G3D_OSX)
             // Based on Apache Portable Runtime

--- a/g3dlite/G3D/System.cpp
+++ b/g3dlite/G3D/System.cpp
@@ -531,7 +531,7 @@ static bool checkForCPUID() {
     // add cases for incompatible architectures if they are added
     // e.g., if we ever support __powerpc__ being defined again
 
-#if defined(__arm__)
+#if defined(__arm__) || defined(__aarch64__)
      return false;
 #else
      return true;
@@ -1740,7 +1740,7 @@ void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, ui
     edx = 0;
 }
 
-#elif defined(G3D_LINUX) && defined(__arm__)
+#elif defined(G3D_LINUX) && defined(__arm__) || defined(__aarch64__)
 // non-x86 CPU; no CPUID, at least in userspace
 void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, uint32& edx) {
     eax = 0;
@@ -1755,7 +1755,7 @@ void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, ui
 // for a discussion of why the second version saves ebx; it allows 32-bit code to compile with the -fPIC option.
 // On 64-bit x86, PIC code has a dedicated rip register for PIC so there is no ebx conflict.
 void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, uint32& edx) {
-#if ! defined(__PIC__) || defined(__x86_64__)
+#if ! defined(__PIC__) || defined(__x86_64__) || defined(__aarch64__)
     // AT&T assembler syntax
     asm volatile(
                  "movl $0, %%ecx   \n\n" /* Wipe ecx */

--- a/g3dlite/G3D/platform.h
+++ b/g3dlite/G3D/platform.h
@@ -268,7 +268,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
 #       ifndef __stdcall
 #           define __stdcall
 #       endif
-#   elif defined(__arm__)
+#   elif defined(__arm__) || defined(__aarch64__)
         // CDECL does not apply to arm.
 #       define __cdecl
 #   endif // calling conventions


### PR DESCRIPTION
Compiling on arm64 architecture has failied in case of define(__arm__) switch cases will only apply on arm32v7 plattforms.
For arm64v8 define(__aarch64__) is needed. This has been applied now. Sourcode successfully compiled on arm64v8/ubuntu:18.04 with the following config: 

cmake ../sources/ -DBUILD_MANGOSD=1 -DBUILD_REALMD=1 -DBUILD_TOOLS=0
make -j16
make install

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/mangosdeps/26)
<!-- Reviewable:end -->
