### PR TITLE
use standart cmake pch support for acelite

### DIFF
--- a/acelite/CMakeLists.txt
+++ b/acelite/CMakeLists.txt
@@ -355,5 +355,5 @@ target_compile_definitions(ace
 )
 
 if(PCH)
-    add_cxx_pch(ace ${CMAKE_CURRENT_SOURCE_DIR}/pch.h ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp)
+    target_precompile_headers(ace PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/pch.h ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp)
 endif()


### PR DESCRIPTION
This replaces ADD_PCH macro with standart cmake function
Change requires to use atleast cmake 3.16 (or newer)
https://cmake.org/cmake/help/latest/command/target_precompile_headers.html

Tested on:
Windows 10 64bit
visual studio 2022
mysql 8
openssl 3.3.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/mangosDeps/39)
<!-- Reviewable:end -->
