### PR TITLE
Fix ACE checked iterator build with MSVC 19.50+

### DIFF
--- a/acelite/ace/checked_iterator.h
+++ b/acelite/ace/checked_iterator.h
@@ -30,12 +30,13 @@
  * @author Ossama Othman
  */
 
-# if defined (_MSC_VER) && (_MSC_FULL_VER >= 140050000) && (!defined (_STLPORT_VERSION))
-// Checked iterators are currently only supported in MSVC++ 8 or better.
+# if defined (_MSC_VER) && (_MSC_FULL_VER >= 140050000) && (!defined (_STLPORT_VERSION)) && (_MSC_VER < 1950)
+// Checked iterators are currently only supported in MSVC++ 8 or better,
+// and were removed in MSVC 19.50 / Visual Studio 2026.
 #  include <iterator>
-# endif  /* _MSC_VER >= 1400 && !_STLPORT_VERSION */
+# endif  /* _MSC_VER >= 1400 && !_STLPORT_VERSION && _MSC_VER < 1950 */
 
-# if defined (_MSC_VER) && (_MSC_FULL_VER >= 140050000) && (!defined (_STLPORT_VERSION))
+# if defined (_MSC_VER) && (_MSC_FULL_VER >= 140050000) && (!defined (_STLPORT_VERSION)) && (_MSC_VER < 1950)
 template <typename PTR>
 stdext::checked_array_iterator<PTR>
 ACE_make_checked_array_iterator (PTR buf, size_t len)
@@ -51,6 +52,6 @@ ACE_make_checked_array_iterator (PTR buf, size_t /* len */)
   // the buffer itself.
   return buf;
 }
-# endif  /* _MSC_VER >= 1400 && !_STLPORT_VERSION */
+# endif  /* _MSC_VER >= 1400 && !_STLPORT_VERSION && _MSC_VER < 1950 */
 
 #endif  /* ACE_CHECKED_ITERATOR_H */


### PR DESCRIPTION
## Summary

Fixes ACE compilation with MSVC 19.50+ / VS 2026.

MSVC 19.51 no longer provides the non-standard `stdext::checked_array_iterator`, which caused ACE to fail with:

```text
dep\acelite\ace\checked_iterator.h(40,1): error C2653: 'stdext': is not a class or namespace name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/mangosDeps/42)
<!-- Reviewable:end -->
